### PR TITLE
Add build pipeline for docker images

### DIFF
--- a/.github/workflows/publish_docker.yml
+++ b/.github/workflows/publish_docker.yml
@@ -1,0 +1,39 @@
+name: Publish a Docker image
+
+on:
+  workflow_dispatch: 
+    inputs:
+      version:
+        description: 'The version of the Docker image (e.g. 0.1.0)'
+        required: true
+        default: ''
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@v6.8.0
+        with:
+          context: .
+          push: true
+          tags: 
+            prolfqua/prolfquapp:latest,prolfqua/prolfquapp:${{ github.event.inputs.version }}
+      

--- a/inst/application/bin/prolfquapp_docker.sh
+++ b/inst/application/bin/prolfquapp_docker.sh
@@ -9,7 +9,7 @@ set -euo pipefail
 
 # Default values for arguments
 IMAGE_VERSION="0.0.5"
-IMAGE_REPO="docker.io/leoschwarz/prolfquapp"
+IMAGE_REPO="docker.io/prolfqua/prolfquapp"
 
 # Function to print usage/help message
 usage() {


### PR DESCRIPTION
This adds the CD pipeline to build and publish the docker image to Docker Hub, for now, only manually.

The run script is updated to use the new URL.