### PR TITLE
Update Dockerfile to install TinyTeX using wget and gdebi

### DIFF
--- a/.github/workflows/formula.qmd
+++ b/.github/workflows/formula.qmd
@@ -1,0 +1,9 @@
+# Formula
+
+```{r}
+print(10+1)
+```
+
+because
+
+$$e=mc^2$$

--- a/.github/workflows/publish_docker.yml
+++ b/.github/workflows/publish_docker.yml
@@ -38,3 +38,9 @@ jobs:
           context: .
           push: true
           tags: prolfqua/prolfquapp:latest,prolfqua/prolfquapp:${{ env.VERSION }}
+      
+      - name: Test Quarto PDF rendering with TinyTeX
+        run: |
+          docker run --rm -v ${{ github.workspace }}/.github/workflows:/workspace prolfqua/prolfquapp:${{ env.VERSION }} \
+            quarto render /workspace/formula.qmd --to pdf
+          echo "✅ Quarto successfully rendered PDF with TinyTeX"

--- a/.github/workflows/publish_docker.yml
+++ b/.github/workflows/publish_docker.yml
@@ -2,6 +2,11 @@ name: Publish a Docker image
 
 on:
   workflow_dispatch:
+    inputs:
+      test-only:
+        description: 'Test build only (no publish to Docker Hub)'
+        type: boolean
+        default: false
 
 jobs:
   build-and-push-image:
@@ -15,17 +20,23 @@ jobs:
         with:
           fetch-depth: 0
       
-      - name: Get version from Git tag
+      - name: Get version from Git tag or use test
         run: |
-          VERSION=$(git tag --points-at HEAD | grep -E '^[0-9]+\.[0-9]+\.[0-9]+' | head -n 1)
-          if [ -z "$VERSION" ]; then
-            echo "::error::No semantic version tag (X.Y.Z) found at HEAD"
-            exit 1
+          if [ "${{ github.event.inputs.test-only }}" = "false" ]; then
+            VERSION=$(git tag --points-at HEAD | grep -E '^[0-9]+\.[0-9]+\.[0-9]+' | head -n 1)
+            if [ -z "$VERSION" ]; then
+              echo "::error::No semantic version tag (X.Y.Z) found at HEAD"
+              exit 1
+            fi
+            echo "VERSION=$VERSION" >> $GITHUB_ENV
+            echo "Using version: $VERSION"
+          else
+            echo "VERSION=test" >> $GITHUB_ENV
+            echo "Using test version (no publish)"
           fi
-          echo "VERSION=$VERSION" >> $GITHUB_ENV
-          echo "Using version: $VERSION"
       
       - name: Login to Docker Hub
+        if: ${{ github.event.inputs.test-only == 'false' }}
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -36,7 +47,7 @@ jobs:
         uses: docker/build-push-action@v6.10.0
         with:
           context: .
-          push: true
+          push: ${{ github.event.inputs.test-only == 'false' }}
           tags: prolfqua/prolfquapp:latest,prolfqua/prolfquapp:${{ env.VERSION }}
       
       - name: Test Quarto PDF rendering with TinyTeX

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,13 +38,14 @@ RUN R -e 'options(warn=2); pak::pkg_install("/opt/prolfqua", upgrade = FALSE)'
 FROM base
 ENV HOME=/home/user
 ARG TINYTEX_VERSION=2025.07
-RUN wget "https://github.com/rstudio/tinytex-releases/releases/download/v${TINYTEX_VERSION}/texlive-local.deb" -O /tmp/texlive-local.deb \
-  && gdebi --non-interactive /tmp/texlive-local.deb \
-  && rm /tmp/texlive-local.deb
+RUN wget "https://github.com/rstudio/tinytex-releases/releases/download/v${TINYTEX_VERSION}/TinyTeX-1-v${TINYTEX_VERSION}.tar.gz" -O /tmp/tinytex.tar.gz \
+  && tar -xzf /tmp/tinytex.tar.gz -C /opt \
+  && rm /tmp/tinytex.tar.gz
 RUN mkdir -p /home/user && chmod -R 777 /home/user
 COPY --from=build /opt/r-libs-site /opt/r-libs-site
 RUN mkdir -p /tmp/quarto-cache && chmod 0777 /tmp/quarto-cache
 ENV XDG_CACHE_HOME=/tmp/quarto-cache
 ENV R_LIBS_USER=/opt/r-libs-site
+RUN for dir in /opt/.TinyTeX/bin/*/; do ln -sf $dir* /usr/local/bin/; done
 ENV PATH="/opt/r-libs-site/prolfquapp/application/bin:/root/.local/bin:${PATH}"
 ENTRYPOINT ["/bin/bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,11 @@ RUN R -e 'options(warn=2); pak::pkg_install("/opt/prolfqua", upgrade = FALSE)'
 
 FROM base
 ENV HOME=/home/user
-RUN quarto install tinytex && chmod -R 777 /home/user
+ARG TINYTEX_VERSION=2025.07
+RUN wget "https://github.com/rstudio/tinytex-releases/releases/download/v${TINYTEX_VERSION}/texlive-local.deb" -O /tmp/texlive-local.deb \
+  && gdebi --non-interactive /tmp/texlive-local.deb \
+  && rm /tmp/texlive-local.deb
+RUN mkdir -p /home/user && chmod -R 777 /home/user
 COPY --from=build /opt/r-libs-site /opt/r-libs-site
 RUN mkdir -p /tmp/quarto-cache && chmod 0777 /tmp/quarto-cache
 ENV XDG_CACHE_HOME=/tmp/quarto-cache


### PR DESCRIPTION
This pull request introduces several changes to enhance the Docker image build process, improve flexibility in testing workflows, and update dependencies for PDF rendering. The most important changes include adding a test-only mode to the Docker publishing workflow, updating TinyTeX installation in the Dockerfile, and enabling Quarto PDF rendering tests.

### Dependency updates:

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L40-R49): Replaced the `quarto install tinytex` command with manual installation of TinyTeX from a specific version's tarball. Added symbolic links to TinyTeX binaries for easier access.

### Testing enhancements:

* [`.github/workflows/publish_docker.yml`](diffhunk://#diff-2f6c87a56dcd8d1625182300f180b425ee8b724978560eb0271cfcc2ee79dfa0L39-R57): Added a new step to test Quarto PDF rendering using TinyTeX. This step verifies that the Docker image can successfully render a PDF from the `formula.qmd` file.
