### PR TITLE
fix(annotation): ignore empty grouping candidates before bait-preference

### DIFF
--- a/R/R6_AnnotationProcessor.R
+++ b/R/R6_AnnotationProcessor.R
@@ -417,6 +417,21 @@ AnnotationProcessor <- R6::R6Class(
         value = TRUE,
         ignore.case = TRUE
       )
+      # Drop candidate columns that carry no information (all NA / all blank).
+      # Datasets frequently ship an empty "Bait ID" column alongside a populated
+      # "Grouping Var"; without this filter the bait-preference below would pick
+      # the empty column, yielding an all-NA grouping factor that crashes the
+      # missingness heatmap (pheatmap: "'gpar' element 'fill' must not be length 0").
+      non_empty <- vapply(
+        groupingVAR,
+        function(col) {
+          any(!is.na(annot[[col]]) & trimws(as.character(annot[[col]])) != "")
+        },
+        logical(1)
+      )
+      if (any(non_empty)) {
+        groupingVAR <- groupingVAR[non_empty]
+      }
       if (any(grepl("^bait", groupingVAR, ignore.case = TRUE))) {
         groupingVAR <- grep(
           "^bait",

--- a/tests/testthat/test-R6_AnnotationProcessor.R
+++ b/tests/testthat/test-R6_AnnotationProcessor.R
@@ -64,3 +64,25 @@ test_that("read_annotation does not overwrite duplicate short sample names", {
   expect_equal(result$annot$Name, annotation$Name)
   expect_equal(result$annot$sampleName, c("control", "control_1", "treat"))
 })
+
+test_that("empty bait column does not hijack a populated grouping variable", {
+  # Mirrors A386 QC datasets: a populated "Grouping Var" alongside an empty
+  # "Bait ID". The grouping pattern matches both; the empty bait column must
+  # not win, otherwise the grouping factor is all-NA and the QC missingness
+  # heatmap crashes in pheatmap (gpar fill length 0).
+  annotation <- data.frame(
+    raw.file = paste0("file_", 1:3, ".raw"),
+    Name = c("s1", "s2", "s3"),
+    "Grouping Var" = c("A", "A", "B"),
+    "Bait ID" = c("", "", ""),
+    check.names = FALSE,
+    stringsAsFactors = FALSE
+  )
+
+  result <- prolfquapp::read_annotation(annotation, repeated = FALSE, QC = TRUE)
+
+  grouping_col <- result$atable$factors[[result$atable$factor_keys()[1]]]
+  expect_equal(grouping_col, "Grouping Var")
+  expect_true(all(!is.na(result$annot[[grouping_col]])))
+  expect_setequal(unique(result$annot[[grouping_col]]), c("A", "B"))
+})


### PR DESCRIPTION
set_grouping_var matches grouping_pattern ("^group|^bait|^Experiment"), then prefers a ^bait column. bfabric DIA datasets routinely ship an empty "Bait ID" column next to a populated "Grouping Var" (e.g. A386 WU347491); the bait-preference then selected the all-blank "Bait ID", producing an all-NA grouping factor that crashed the QC missingness heatmap in pheatmap ("'gpar' element 'fill' must not be length 0").

Drop candidates that carry no information (all NA / blank) before applying the bait-preference, so bait wins only among columns that actually contain data. Populated-bait AP-MS datasets are unaffected.

Add a regression test mirroring the A386 shape (populated "Grouping Var" + empty "Bait ID" -> grouping var chosen, no NAs).